### PR TITLE
fixes #26: {int1, int2, int4, int8, float4, float8} × {scalar, array, slice} now work

### DIFF
--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/ArrayBuilder.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/ArrayBuilder.java
@@ -114,6 +114,7 @@ public class ArrayBuilder {
 
                 int numbytes = basketkeys[j - 1].fLast - basketkeys[j - 1].fKeylen;
                 long numitems = interpretation.numitems(numbytes, (int)numentries);
+
                 totalitems += numitems;
                 if (totalitems != (int)totalitems) {
                     throw new IllegalArgumentException("number of items requested of ArrayBuilder.build must fit into a 32-bit integer");

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -78,15 +78,6 @@ public abstract class PrimitiveArray extends Array {
 
     protected abstract Array make(ByteBuffer out);
 
-    @Override
-    public Object toArray(boolean bigEndian) {
-        this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-        FloatBuffer buf = this.buffer.asFloatBuffer();
-        float[] out = new float[buf.limit() - buf.position()];
-        buf.get(out);
-        return out;
-    }
-
     /////////////////////////////////////////////////////////////////////////// Bool
 
     /*

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -148,8 +148,8 @@ public abstract class PrimitiveArray extends Array {
             return new Bool(this.interpretation.subarray(), this.buffer);
         }
 
-        public boolean toBoolean() {
-            return (this.buffer.get(0) != 0);
+        public boolean toBoolean(int index) {
+            return (this.buffer.get(index) != 0);
         }
 
         @Override
@@ -211,8 +211,8 @@ public abstract class PrimitiveArray extends Array {
             return new Int1(this.interpretation.subarray(), this.buffer);
         }
 
-        public byte toByte() {
-            return this.buffer.get(0);
+        public byte toByte(int index) {
+            return this.buffer.get(index);
         }
 
         @Override
@@ -274,8 +274,8 @@ public abstract class PrimitiveArray extends Array {
             return new Int2(this.interpretation.subarray(), this.buffer);
         }
 
-        public short toShort() {
-            return this.buffer.asShortBuffer().get(0);
+        public short toShort(int index) {
+            return this.buffer.asShortBuffer().get(index);
         }
 
         @Override
@@ -337,8 +337,8 @@ public abstract class PrimitiveArray extends Array {
             return new Int4(this.interpretation.subarray(), this.buffer);
         }
 
-        public int toInt() {
-            return this.buffer.asIntBuffer().get(0);
+        public int toInt(int index) {
+            return this.buffer.asIntBuffer().get(index);
         }
 
         @Override
@@ -421,8 +421,8 @@ public abstract class PrimitiveArray extends Array {
             return new Int8(this.interpretation.subarray(), this.buffer);
         }
 
-        public long toLong() {
-            return this.buffer.asLongBuffer().get(0);
+        public long toLong(int index) {
+            return this.buffer.asLongBuffer().get(index);
         }
 
         @Override
@@ -484,8 +484,8 @@ public abstract class PrimitiveArray extends Array {
             return new Float4(this.interpretation.subarray(), this.buffer);
         }
 
-        public float toFloat() {
-            return this.buffer.asFloatBuffer().get(0);
+        public float toFloat(int index) {
+            return this.buffer.asFloatBuffer().get(index);
         }
 
         @Override
@@ -547,8 +547,8 @@ public abstract class PrimitiveArray extends Array {
             return new Float8(this.interpretation.subarray(), this.buffer);
         }
 
-        public double toDouble() {
-            return this.buffer.asDoubleBuffer().get(0);
+        public double toDouble(int index) {
+            return this.buffer.asDoubleBuffer().get(index);
         }
 
         @Override

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -198,7 +198,7 @@ public abstract class PrimitiveArray extends Array {
         }
 
         public byte toByte(int index) {
-            return this.buffer.get(index);
+            return this.buffer.get(this.buffer.position() + index);
         }
 
         @Override

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -87,11 +87,6 @@ public abstract class PrimitiveArray extends Array {
         return out;
     }
 
-    @Override
-    public String toString() {
-        return Arrays.toString((float[])this.toArray());
-    }
-
     /////////////////////////////////////////////////////////////////////////// Bool
 
     /*
@@ -427,7 +422,7 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public String toString() {
-            return Arrays.toString((float[])this.toArray());
+            return Arrays.toString((long[])this.toArray());
         }
     }
 
@@ -553,7 +548,7 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public String toString() {
-            return Arrays.toString((float[])this.toArray());
+            return Arrays.toString((double[])this.toArray());
         }
     }
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
@@ -51,7 +51,7 @@ public class AsJagged implements Interpretation {
         RawArray compact = bytedata.compact(byteoffsets, this.skipbytes, local_entrystart, local_entrystop);
 
         int innersize = ((AsDtype)this.content).itemsize() * ((AsDtype)this.content).multiplicity();
-        ByteBuffer countsbuf = ByteBuffer.allocate((local_entrystop - local_entrystart) * innersize);
+        ByteBuffer countsbuf = ByteBuffer.allocate((local_entrystop - local_entrystart) * 4);
         int total = 0;
         for (int i = local_entrystart;  i < local_entrystop;  i++) {
             int count = (byteoffsets.get(i + 1) - byteoffsets.get(i)) / innersize;

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/ArrayColumnVector.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/ArrayColumnVector.java
@@ -58,8 +58,6 @@ public class ArrayColumnVector extends ColumnVector {
 
     @Override
     public int getInt(int rowId) {
-        System.out.println(String.format("getInt %d", rowId));
-
         return ((PrimitiveArray.Int4)array).toInt();
     }
 
@@ -135,8 +133,6 @@ public class ArrayColumnVector extends ColumnVector {
 
     @Override
     public int[] getInts(int rowId, int count) {
-        System.out.println(String.format("getInts %d %d", rowId, count));
-
         return (int[])array.toArray();
     }
 

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/ArrayColumnVector.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/ArrayColumnVector.java
@@ -58,6 +58,8 @@ public class ArrayColumnVector extends ColumnVector {
 
     @Override
     public int getInt(int rowId) {
+        System.out.println(String.format("getInt %d", rowId));
+
         return ((PrimitiveArray.Int4)array).toInt();
     }
 
@@ -133,6 +135,8 @@ public class ArrayColumnVector extends ColumnVector {
 
     @Override
     public int[] getInts(int rowId, int count) {
+        System.out.println(String.format("getInts %d %d", rowId, count));
+
         return (int[])array.toArray();
     }
 

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/ArrayColumnVector.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/ArrayColumnVector.java
@@ -43,37 +43,37 @@ public class ArrayColumnVector extends ColumnVector {
 
     @Override
     public boolean getBoolean(int rowId) {
-        return ((PrimitiveArray.Bool)array).toBoolean();
+        return ((PrimitiveArray.Bool)array).toBoolean(rowId);
     }
 
     @Override
     public byte getByte(int rowId) {
-        return ((PrimitiveArray.Int1)array).toByte();
+        return ((PrimitiveArray.Int1)array).toByte(rowId);
     }
 
     @Override
     public short getShort(int rowId) {
-        return ((PrimitiveArray.Int2)array).toShort();
+        return ((PrimitiveArray.Int2)array).toShort(rowId);
     }
 
     @Override
     public int getInt(int rowId) {
-        return ((PrimitiveArray.Int4)array).toInt();
+        return ((PrimitiveArray.Int4)array).toInt(rowId);
     }
 
     @Override
     public long getLong(int rowId) {
-        return ((PrimitiveArray.Int8)array).toLong();
+        return ((PrimitiveArray.Int8)array).toLong(rowId);
     }
 
     @Override
     public float getFloat(int rowId) {
-        return ((PrimitiveArray.Float4)array).toFloat();
+        return ((PrimitiveArray.Float4)array).toFloat(rowId);
     }
 
     @Override
     public double getDouble(int rowId) {
-        return ((PrimitiveArray.Float8)array).toDouble();
+        return ((PrimitiveArray.Float8)array).toDouble(rowId);
     }
 
     @Override

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/TTreeColumnVector.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/TTreeColumnVector.java
@@ -38,16 +38,16 @@ public class TTreeColumnVector extends ColumnVector {
         TBranch.ArrayDescriptor desc = slimBranch.getArrayDesc();
         if (desc == null) {
             logger.trace("  scalar vec");
-            Interpretation interpretation = new AsDtype(dtype);   // FIXME
+            Interpretation interpretation = new AsDtype(dtype);
             this.builder = new ArrayBuilder(getbasket, interpretation, basketEntryOffsets, executor, entrystart, entrystop);
         }
         else if (desc.isFixed()) {
             logger.trace("  fixed vec");
-            Interpretation interpretation = new AsDtype(dtype, Arrays.asList(desc.getFixedLength()));   // FIXME
+            Interpretation interpretation = new AsDtype(dtype, Arrays.asList(desc.getFixedLength()));
             this.builder = new ArrayBuilder(getbasket, interpretation, basketEntryOffsets, executor, entrystart, entrystop);
         } else {
             logger.trace("  slice vec");
-            Interpretation interpretation = new AsJagged(new AsDtype(dtype));   // FIXME
+            Interpretation interpretation = new AsJagged(new AsDtype(dtype));
             this.builder = new ArrayBuilder(getbasket, interpretation, basketEntryOffsets, executor, entrystart, entrystop);
         }
     }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/TTreeColumnVector.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/TTreeColumnVector.java
@@ -108,7 +108,6 @@ public class TTreeColumnVector extends ColumnVector {
 
     @Override
     public double getDouble(int rowId) {
-        // TODO Auto-generated method stub
         return getDoubles(rowId, 1)[0];
     }
 
@@ -116,8 +115,7 @@ public class TTreeColumnVector extends ColumnVector {
     public ColumnarArray getArray(int rowId) {
         Array array = builder.getArray(rowId, 1).subarray();
         ArrayColumnVector tmpvec = new ArrayColumnVector(((ArrayType)dataType()).elementType(), array);
-        ColumnarArray tmp = new ColumnarArray(tmpvec, 0, array.length());
-        return tmp;
+        return new ColumnarArray(tmpvec, 0, array.length());
     }
 
     @Override

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/TTreeColumnVector.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/TTreeColumnVector.java
@@ -35,8 +35,6 @@ public class TTreeColumnVector extends ColumnVector {
         this.basketEntryOffsets = slimBranch.getBasketEntryOffsets();
         this.getbasket = slimBranch.getArrayBranchCallback(basketCache);
 
-
-
         TBranch.ArrayDescriptor desc = slimBranch.getArrayDesc();
         if (desc == null) {
             logger.trace("  scalar vec");

--- a/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
+++ b/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
@@ -26,20 +26,6 @@ import edu.vanderbilt.accre.laurelin.root_proxy.TTree;
 import edu.vanderbilt.accre.laurelin.spark_ttree.SlimTBranch;
 
 public class TTreeTest {
-    @Test
-    public void testIntegers() throws IOException {
-        TFile f = TFile.getFromFile("testdata/all-types.root");
-        TTree t = new TTree(f.getProxy("Events"), f);
-        TBranch b = t.getBranches("ScalarI32").get(0);
-        Cache cache = new Cache();
-        SlimTBranch slimBranch = SlimTBranch.getFromTBranch(b);
-        ArrayBuilder.GetBasket getbasket = slimBranch.getArrayBranchCallback(cache);
-        long []basketEntryOffsets = slimBranch.getBasketEntryOffsets();
-        AsDtype asdtype = new AsDtype(AsDtype.Dtype.INT4);
-        ArrayBuilder builder = new ArrayBuilder(getbasket, asdtype, basketEntryOffsets, null, 0, 9);
-        System.out.println(Arrays.toString((int[])builder.getArray(0, 9).toArray()));
-    }
-
     private TTree getTestTree() throws IOException {
         String testPath = "testdata/uproot-small-flat-tree.root";
         String testTree = "tree";

--- a/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
+++ b/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
@@ -25,6 +25,18 @@ import edu.vanderbilt.accre.laurelin.root_proxy.TTree;
 import edu.vanderbilt.accre.laurelin.spark_ttree.SlimTBranch;
 
 public class TTreeTest {
+    @Test
+    public void testIntegers() throws IOException {
+        TFile f = TFile.getFromFile("testdata/all-types.root");
+        TTree t = new TTree(f.getProxy("Events"), f);
+        TBranch b = t.getBranches("ScalarI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slimBranch = SlimTBranch.getFromTBranch(b);
+        ArrayBuilder.GetBasket getbasket = slimBranch.getArrayBranchCallback(cache);
+        long []basketEntryOffsets = slimBranch.getBasketEntryOffsets();
+        AsDtype asdtype = new AsDtype(AsDtype.Dtype.INT4);
+        ArrayBuilder builder = new ArrayBuilder(getbasket, asdtype, basketEntryOffsets, null, 0, 9);
+    }
 
     private TTree getTestTree() throws IOException {
         String testPath = "testdata/uproot-small-flat-tree.root";

--- a/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
+++ b/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assume.assumeTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;

--- a/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
+++ b/src/test/java/edu/vanderbilt/accre/root_proxy/TTreeTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assume.assumeTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -36,6 +37,7 @@ public class TTreeTest {
         long []basketEntryOffsets = slimBranch.getBasketEntryOffsets();
         AsDtype asdtype = new AsDtype(AsDtype.Dtype.INT4);
         ArrayBuilder builder = new ArrayBuilder(getbasket, asdtype, basketEntryOffsets, null, 0, 9);
+        System.out.println(Arrays.toString((int[])builder.getArray(0, 9).toArray()));
     }
 
     private TTree getTestTree() throws IOException {

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceIntegrationTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceIntegrationTest.java
@@ -56,11 +56,7 @@ public class TTreeDataSourceIntegrationTest {
         df.printSchema();
         df.select("ScalarI8", "ScalarI16", "ScalarI32", "ScalarI64").show();
         df.select("ArrayI8", "ArrayI16", "ArrayI32", "ArrayI64").show();
-        df.select("SliceI32").show();
-        // array form is incorrect, slice form bombs
-        df.select("ScalarI1", "ScalarUI1", "ArrayI1", "ArrayUI1").show();
-        // following code bombs
-        // df.select("SliceI8", "SliceI16", "SliceI64").show();
+        df.select("SliceI8", "SliceI16", "SliceI32", "SliceI64").show();
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -24,6 +24,8 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.ByteType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MetadataBuilder;
@@ -239,6 +241,234 @@ public class TTreeDataSourceUnitTest {
         assertFloatArrayEquals(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, float32col.getArray(0).toFloatArray());
         assertFloatArrayEquals(new float[] { 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f}, float32col.getArray(10).toFloatArray());
         assertFloatArrayEquals(new float[] { 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f}, float32col.getArray(31).toFloatArray());
+    }
+
+    @Test
+    public void testScalarI8() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarI8").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ByteType(), SimpleType.fromString("byte"), SimpleType.dtypeFromString("byte"), cache, 0, 9, slim, null);
+        assertEquals(result.getByte(0), 0);
+        assertEquals(result.getByte(1), 1);
+        assertEquals(result.getByte(2), 2);
+        assertEquals(result.getByte(3), -128);
+        assertEquals(result.getByte(4), -127);
+        assertEquals(result.getByte(5), -126);
+        assertEquals(result.getByte(6), 127);
+        assertEquals(result.getByte(7), 126);
+        assertEquals(result.getByte(8), 125);
+    }
+
+    @Test
+    public void testArrayI8() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayI8").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ByteType(), false), new SimpleType.ArrayType(SimpleType.fromString("byte")), SimpleType.dtypeFromString("byte"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getByte(0), 0);
+        assertEquals(event0.getByte(1), 0);
+        assertEquals(event0.getByte(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getByte(0), 1);
+        assertEquals(event1.getByte(1), 1);
+        assertEquals(event1.getByte(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getByte(0), 2);
+        assertEquals(event2.getByte(1), 2);
+        assertEquals(event2.getByte(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getByte(0), -128);
+        assertEquals(event3.getByte(1), -128);
+        assertEquals(event3.getByte(2), -128);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getByte(0), -127);
+        assertEquals(event4.getByte(1), -127);
+        assertEquals(event4.getByte(2), -127);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getByte(0), -126);
+        assertEquals(event5.getByte(1), -126);
+        assertEquals(event5.getByte(2), -126);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getByte(0), 127);
+        assertEquals(event6.getByte(1), 127);
+        assertEquals(event6.getByte(2), 127);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getByte(0), 126);
+        assertEquals(event7.getByte(1), 126);
+        assertEquals(event7.getByte(2), 126);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getByte(0), 125);
+        assertEquals(event8.getByte(1), 125);
+        assertEquals(event8.getByte(2), 125);
+    }
+
+    @Test
+    public void testSliceI8() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceI8").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ByteType(), false), new SimpleType.ArrayType(SimpleType.fromString("byte")), SimpleType.dtypeFromString("byte"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getByte(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getByte(0), 2);
+        assertEquals(event2.getByte(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getByte(0), -127);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getByte(0), -126);
+        assertEquals(event5.getByte(1), -126);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getByte(0), 126);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getByte(0), 125);
+        assertEquals(event8.getByte(1), 125);
+    }
+
+    @Test
+    public void testScalarI16() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarI16").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ShortType(), SimpleType.fromString("short"), SimpleType.dtypeFromString("short"), cache, 0, 9, slim, null);
+        assertEquals(result.getShort(0), 0);
+        assertEquals(result.getShort(1), 1);
+        assertEquals(result.getShort(2), 2);
+        assertEquals(result.getShort(3), -32768);
+        assertEquals(result.getShort(4), -32767);
+        assertEquals(result.getShort(5), -32766);
+        assertEquals(result.getShort(6), 32767);
+        assertEquals(result.getShort(7), 32766);
+        assertEquals(result.getShort(8), 32765);
+    }
+
+    @Test
+    public void testArrayI16() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayI16").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ShortType(), false), new SimpleType.ArrayType(SimpleType.fromString("short")), SimpleType.dtypeFromString("short"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getShort(0), 0);
+        assertEquals(event0.getShort(1), 0);
+        assertEquals(event0.getShort(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getShort(0), 1);
+        assertEquals(event1.getShort(1), 1);
+        assertEquals(event1.getShort(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getShort(0), 2);
+        assertEquals(event2.getShort(1), 2);
+        assertEquals(event2.getShort(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getShort(0), -32768);
+        assertEquals(event3.getShort(1), -32768);
+        assertEquals(event3.getShort(2), -32768);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getShort(0), -32767);
+        assertEquals(event4.getShort(1), -32767);
+        assertEquals(event4.getShort(2), -32767);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getShort(0), -32766);
+        assertEquals(event5.getShort(1), -32766);
+        assertEquals(event5.getShort(2), -32766);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getShort(0), 32767);
+        assertEquals(event6.getShort(1), 32767);
+        assertEquals(event6.getShort(2), 32767);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getShort(0), 32766);
+        assertEquals(event7.getShort(1), 32766);
+        assertEquals(event7.getShort(2), 32766);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getShort(0), 32765);
+        assertEquals(event8.getShort(1), 32765);
+        assertEquals(event8.getShort(2), 32765);
+    }
+
+    @Test
+    public void testSliceI16() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceI16").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ShortType(), false), new SimpleType.ArrayType(SimpleType.fromString("short")), SimpleType.dtypeFromString("short"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getShort(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getShort(0), 2);
+        assertEquals(event2.getShort(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getShort(0), -32767);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getShort(0), -32766);
+        assertEquals(event5.getShort(1), -32766);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getShort(0), 32766);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getShort(0), 32765);
+        assertEquals(event8.getShort(1), 32765);
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -53,8 +53,8 @@ public class TTreeDataSourceUnitTest {
         long []basketEntryOffsets = slimBranch.getBasketEntryOffsets();
         AsDtype interpretation = new AsDtype(AsDtype.Dtype.INT4);
         ArrayBuilder builder = new ArrayBuilder(getbasket, interpretation, basketEntryOffsets, null, 0, 9);
-        ArrayColumnVector result = new ArrayColumnVector(new IntegerType(), builder.getArray(0, 9));
-        assert Arrays.toString(result.getInts(0, 9)).equals("[0, 1, 2, -2147483648, -2147483647, -2147483646, 2147483647, 2147483646, 2147483645]");
+        // ArrayColumnVector result = new ArrayColumnVector(new IntegerType(), builder.getArray(0, 9));
+        // assert Arrays.toString(result.getInts(0, 9)).equals("[0, 1, 2, -2147483648, -2147483647, -2147483646, 2147483647, 2147483646, 2147483645]");
         // assert result.getInt(0) == 0;
         // assert result.getInt(1) == 1;
         // assert result.getInt(2) == 2;
@@ -80,7 +80,7 @@ public class TTreeDataSourceUnitTest {
                 .option("threadCount", "1")
                 .load("testdata/all-types.root");
         df.printSchema();
-        df.select("ScalarI32").show();
+        df.select("SliceI32").show();
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -48,52 +48,6 @@ import edu.vanderbilt.accre.laurelin.spark_ttree.TTreeColumnVector;
 
 public class TTreeDataSourceUnitTest {
     @Test
-    public void testInt32() throws IOException {
-        TFile file = TFile.getFromFile("testdata/all-types.root");
-        TTree tree = new TTree(file.getProxy("Events"), file);
-        TBranch branch = tree.getBranches("SliceI32").get(0);
-        Cache cache = new Cache();
-        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
-
-        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("int")), SimpleType.dtypeFromString("int"), cache, 0, 9, slim, null);
-        ColumnarArray event0 = result.getArray(0);
-        System.out.println(String.format("[]"));
-        ColumnarArray event1 = result.getArray(1);
-        System.out.println(String.format("[%d]", event1.getInt(0)));
-        ColumnarArray event2 = result.getArray(2);
-        System.out.println(String.format("[%d, %d]", event2.getInt(0), event2.getInt(1)));
-        ColumnarArray event3 = result.getArray(3);
-        ColumnarArray event4 = result.getArray(4);
-        ColumnarArray event5 = result.getArray(5);
-        ColumnarArray event6 = result.getArray(6);
-        ColumnarArray event7 = result.getArray(7);
-        ColumnarArray event8 = result.getArray(8);
-    }
-
-    @Test
-    public void testInt64() throws IOException {
-        TFile file = TFile.getFromFile("testdata/all-types.root");
-        TTree tree = new TTree(file.getProxy("Events"), file);
-        TBranch branch = tree.getBranches("SliceI64").get(0);
-        Cache cache = new Cache();
-        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
-
-        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new LongType(), false), new SimpleType.ArrayType(SimpleType.fromString("long")), SimpleType.dtypeFromString("long"), cache, 0, 9, slim, null);
-        ColumnarArray event0 = result.getArray(0);
-        System.out.println(String.format("[]"));
-        ColumnarArray event1 = result.getArray(1);
-        System.out.println(String.format("[%d]", event1.getLong(0)));
-        ColumnarArray event2 = result.getArray(2);
-        System.out.println(String.format("[%d, %d]", event2.getLong(0), event2.getLong(1)));
-        ColumnarArray event3 = result.getArray(3);
-        ColumnarArray event4 = result.getArray(4);
-        ColumnarArray event5 = result.getArray(5);
-        ColumnarArray event6 = result.getArray(6);
-        ColumnarArray event7 = result.getArray(7);
-        ColumnarArray event8 = result.getArray(8);
-    }
-
-    @Test
     public void testLoadNestedDataFrame() {
         System.setProperty("hadoop.home.dir", "/");
         SparkSession spark = SparkSession.builder()
@@ -285,6 +239,120 @@ public class TTreeDataSourceUnitTest {
         assertFloatArrayEquals(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, float32col.getArray(0).toFloatArray());
         assertFloatArrayEquals(new float[] { 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f}, float32col.getArray(10).toFloatArray());
         assertFloatArrayEquals(new float[] { 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f}, float32col.getArray(31).toFloatArray());
+    }
+
+    @Test
+    public void testScalarI32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new IntegerType(), SimpleType.fromString("int"), SimpleType.dtypeFromString("int"), cache, 0, 9, slim, null);
+        assertEquals(result.getInt(0), 0);
+        assertEquals(result.getInt(1), 1);
+        assertEquals(result.getInt(2), 2);
+        assertEquals(result.getInt(3), -2147483648);
+        assertEquals(result.getInt(4), -2147483647);
+        assertEquals(result.getInt(5), -2147483646);
+        assertEquals(result.getInt(6), 2147483647);
+        assertEquals(result.getInt(7), 2147483646);
+        assertEquals(result.getInt(8), 2147483645);
+    }
+
+    @Test
+    public void testArrayI32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("int")), SimpleType.dtypeFromString("int"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getInt(0), 0);
+        assertEquals(event0.getInt(1), 0);
+        assertEquals(event0.getInt(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getInt(0), 1);
+        assertEquals(event1.getInt(1), 1);
+        assertEquals(event1.getInt(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getInt(0), 2);
+        assertEquals(event2.getInt(1), 2);
+        assertEquals(event2.getInt(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getInt(0), -2147483648);
+        assertEquals(event3.getInt(1), -2147483648);
+        assertEquals(event3.getInt(2), -2147483648);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getInt(0), -2147483647);
+        assertEquals(event4.getInt(1), -2147483647);
+        assertEquals(event4.getInt(2), -2147483647);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getInt(0), -2147483646);
+        assertEquals(event5.getInt(1), -2147483646);
+        assertEquals(event5.getInt(2), -2147483646);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getInt(0), 2147483647);
+        assertEquals(event6.getInt(1), 2147483647);
+        assertEquals(event6.getInt(2), 2147483647);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getInt(0), 2147483646);
+        assertEquals(event7.getInt(1), 2147483646);
+        assertEquals(event7.getInt(2), 2147483646);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getInt(0), 2147483645);
+        assertEquals(event8.getInt(1), 2147483645);
+        assertEquals(event8.getInt(2), 2147483645);
+    }
+
+    @Test
+    public void testSliceI32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("int")), SimpleType.dtypeFromString("int"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getInt(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getInt(0), 2);
+        assertEquals(event2.getInt(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getInt(0), -2147483647);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getInt(0), -2147483646);
+        assertEquals(event5.getInt(1), -2147483646);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getInt(0), 2147483646);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getInt(0), 2147483645);
+        assertEquals(event8.getInt(1), 2147483645);
     }
 
 }

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -79,8 +79,7 @@ public class TTreeDataSourceUnitTest {
                 .option("tree", "Events")
                 .option("threadCount", "1")
                 .load("testdata/all-types.root");
-        df.printSchema();
-        df.select("SliceI32").show();
+        df.select("SliceI64").show();
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -50,21 +50,6 @@ import edu.vanderbilt.accre.laurelin.spark_ttree.TTreeColumnVector;
 
 public class TTreeDataSourceUnitTest {
     @Test
-    public void testLoadNestedDataFrame() {
-        System.setProperty("hadoop.home.dir", "/");
-        SparkSession spark = SparkSession.builder()
-                .master("local[*]")
-                .appName("test").getOrCreate();
-        Dataset<Row> df = spark
-                .read()
-                .format("edu.vanderbilt.accre.laurelin.Root")
-                .option("tree", "Events")
-                .option("threadCount", "1")
-                .load("testdata/all-types.root");
-        df.select("SliceI32").show();
-    }
-
-    @Test
     public void testMultipleBasketsForiter() throws IOException {
         Map<String, String> optmap = new HashMap<String, String>();
         optmap.put("path", "testdata/uproot-foriter.root");
@@ -251,7 +236,7 @@ public class TTreeDataSourceUnitTest {
         Cache cache = new Cache();
         SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
 
-        TTreeColumnVector result = new TTreeColumnVector(new ByteType(), SimpleType.fromString("byte"), SimpleType.dtypeFromString("byte"), cache, 0, 9, slim, null);
+        TTreeColumnVector result = new TTreeColumnVector(new ByteType(), SimpleType.fromString("char"), SimpleType.dtypeFromString("char"), cache, 0, 9, slim, null);
         assertEquals(result.getByte(0), 0);
         assertEquals(result.getByte(1), 1);
         assertEquals(result.getByte(2), 2);
@@ -271,7 +256,7 @@ public class TTreeDataSourceUnitTest {
         Cache cache = new Cache();
         SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
 
-        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ByteType(), false), new SimpleType.ArrayType(SimpleType.fromString("byte")), SimpleType.dtypeFromString("byte"), cache, 0, 9, slim, null);
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ByteType(), false), new SimpleType.ArrayType(SimpleType.fromString("char")), SimpleType.dtypeFromString("char"), cache, 0, 9, slim, null);
         ColumnarArray event0 = result.getArray(0);
         assertEquals(event0.numElements(), 3);
         assertEquals(event0.getByte(0), 0);
@@ -327,7 +312,7 @@ public class TTreeDataSourceUnitTest {
         Cache cache = new Cache();
         SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
 
-        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ByteType(), false), new SimpleType.ArrayType(SimpleType.fromString("byte")), SimpleType.dtypeFromString("byte"), cache, 0, 9, slim, null);
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ByteType(), false), new SimpleType.ArrayType(SimpleType.fromString("char")), SimpleType.dtypeFromString("char"), cache, 0, 9, slim, null);
         ColumnarArray event0 = result.getArray(0);
         assertEquals(event0.numElements(), 0);
         ColumnarArray event1 = result.getArray(1);

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -28,6 +28,8 @@ import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -682,6 +684,106 @@ public class TTreeDataSourceUnitTest {
         assertEquals(event8.numElements(), 2);
         assertEquals(event8.getLong(0), 9223372036854775805L);
         assertEquals(event8.getLong(1), 9223372036854775805L);
+    }
+
+    @Test
+    public void testFloat32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/uproot-small-flat-tree.root");
+        TTree tree = new TTree(file.getProxy("tree"), file);
+        TBranch branch = tree.getBranches("Float32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new FloatType(), SimpleType.fromString("float"), SimpleType.dtypeFromString("float"), cache, 0, 100, slim, null);
+        for (int i = 0;  i < 100;  i++) {
+            assertEquals(result.getFloat(i), (float)i, 0.0001);
+        }
+    }
+
+    @Test
+    public void testArrayFloat32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/uproot-small-flat-tree.root");
+        TTree tree = new TTree(file.getProxy("tree"), file);
+        TBranch branch = tree.getBranches("ArrayFloat32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new FloatType(), false), new SimpleType.ArrayType(SimpleType.fromString("float")), SimpleType.dtypeFromString("float"), cache, 0, 100, slim, null);
+        for (int i = 0;  i < 100;  i++) {
+            ColumnarArray event = result.getArray(i);
+            assertEquals(event.numElements(), 10);
+            for (int j = 0;  j < 10;  j++) {
+                assertEquals(result.getFloat(i), (float)i, 0.0001);
+            }
+        }
+    }
+
+    @Test
+    public void testSliceFloat32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/uproot-small-flat-tree.root");
+        TTree tree = new TTree(file.getProxy("tree"), file);
+        TBranch branch = tree.getBranches("SliceFloat32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new FloatType(), false), new SimpleType.ArrayType(SimpleType.fromString("float")), SimpleType.dtypeFromString("float"), cache, 0, 100, slim, null);
+        for (int i = 0;  i < 100;  i++) {
+            ColumnarArray event = result.getArray(i);
+            assertEquals(event.numElements(), i % 10);
+            for (int j = 0;  j < i % 10;  j++) {
+                assertEquals(result.getFloat(i), (float)i, 0.0001);
+            }
+        }
+    }
+
+    @Test
+    public void testFloat64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/uproot-small-flat-tree.root");
+        TTree tree = new TTree(file.getProxy("tree"), file);
+        TBranch branch = tree.getBranches("Float64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new DoubleType(), SimpleType.fromString("double"), SimpleType.dtypeFromString("double"), cache, 0, 100, slim, null);
+        for (int i = 0;  i < 100;  i++) {
+            assertEquals(result.getDouble(i), (double)i, 0.0001);
+        }
+    }
+
+    @Test
+    public void testArrayFloat64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/uproot-small-flat-tree.root");
+        TTree tree = new TTree(file.getProxy("tree"), file);
+        TBranch branch = tree.getBranches("ArrayFloat64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new DoubleType(), false), new SimpleType.ArrayType(SimpleType.fromString("double")), SimpleType.dtypeFromString("double"), cache, 0, 100, slim, null);
+        for (int i = 0;  i < 100;  i++) {
+            ColumnarArray event = result.getArray(i);
+            assertEquals(event.numElements(), 10);
+            for (int j = 0;  j < 10;  j++) {
+                assertEquals(result.getDouble(i), (double)i, 0.0001);
+            }
+        }
+    }
+
+    @Test
+    public void testSliceFloat64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/uproot-small-flat-tree.root");
+        TTree tree = new TTree(file.getProxy("tree"), file);
+        TBranch branch = tree.getBranches("SliceFloat64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new DoubleType(), false), new SimpleType.ArrayType(SimpleType.fromString("double")), SimpleType.dtypeFromString("double"), cache, 0, 100, slim, null);
+        for (int i = 0;  i < 100;  i++) {
+            ColumnarArray event = result.getArray(i);
+            assertEquals(event.numElements(), i % 10);
+            for (int j = 0;  j < i % 10;  j++) {
+                assertEquals(result.getDouble(i), (double)i, 0.0001);
+            }
+        }
     }
 
 }

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -355,4 +355,118 @@ public class TTreeDataSourceUnitTest {
         assertEquals(event8.getInt(1), 2147483645);
     }
 
+    @Test
+    public void testScalarI64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarI64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new LongType(), SimpleType.fromString("long"), SimpleType.dtypeFromString("long"), cache, 0, 9, slim, null);
+        assertEquals(result.getLong(0), 0);
+        assertEquals(result.getLong(1), 1);
+        assertEquals(result.getLong(2), 2);
+        assertEquals(result.getLong(3), -9223372036854775808L);
+        assertEquals(result.getLong(4), -9223372036854775807L);
+        assertEquals(result.getLong(5), -9223372036854775806L);
+        assertEquals(result.getLong(6), 9223372036854775807L);
+        assertEquals(result.getLong(7), 9223372036854775806L);
+        assertEquals(result.getLong(8), 9223372036854775805L);
+    }
+
+    @Test
+    public void testArrayI64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayI64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new LongType(), false), new SimpleType.ArrayType(SimpleType.fromString("long")), SimpleType.dtypeFromString("long"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getLong(0), 0);
+        assertEquals(event0.getLong(1), 0);
+        assertEquals(event0.getLong(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getLong(0), 1);
+        assertEquals(event1.getLong(1), 1);
+        assertEquals(event1.getLong(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getLong(0), 2);
+        assertEquals(event2.getLong(1), 2);
+        assertEquals(event2.getLong(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getLong(0), -9223372036854775808L);
+        assertEquals(event3.getLong(1), -9223372036854775808L);
+        assertEquals(event3.getLong(2), -9223372036854775808L);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getLong(0), -9223372036854775807L);
+        assertEquals(event4.getLong(1), -9223372036854775807L);
+        assertEquals(event4.getLong(2), -9223372036854775807L);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getLong(0), -9223372036854775806L);
+        assertEquals(event5.getLong(1), -9223372036854775806L);
+        assertEquals(event5.getLong(2), -9223372036854775806L);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getLong(0), 9223372036854775807L);
+        assertEquals(event6.getLong(1), 9223372036854775807L);
+        assertEquals(event6.getLong(2), 9223372036854775807L);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getLong(0), 9223372036854775806L);
+        assertEquals(event7.getLong(1), 9223372036854775806L);
+        assertEquals(event7.getLong(2), 9223372036854775806L);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getLong(0), 9223372036854775805L);
+        assertEquals(event8.getLong(1), 9223372036854775805L);
+        assertEquals(event8.getLong(2), 9223372036854775805L);
+    }
+
+    @Test
+    public void testSliceI64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceI64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new LongType(), false), new SimpleType.ArrayType(SimpleType.fromString("long")), SimpleType.dtypeFromString("long"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getLong(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getLong(0), 2);
+        assertEquals(event2.getLong(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getLong(0), -9223372036854775807L);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getLong(0), -9223372036854775806L);
+        assertEquals(event5.getLong(1), -9223372036854775806L);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getLong(0), 9223372036854775806L);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getLong(0), 9223372036854775805L);
+        assertEquals(event8.getLong(1), 9223372036854775805L);
+    }
+
 }

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -25,6 +25,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -50,17 +51,17 @@ public class TTreeDataSourceUnitTest {
     public void testIntegers() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
-        TBranch branch = tree.getBranches("SliceI32").get(0);
+        TBranch branch = tree.getBranches("SliceI64").get(0);
         Cache cache = new Cache();
         SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
 
-        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("int")), SimpleType.dtypeFromString("int"), cache, 0, 9, slim, null);
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new LongType(), false), new SimpleType.ArrayType(SimpleType.fromString("long")), SimpleType.dtypeFromString("long"), cache, 0, 9, slim, null);
         ColumnarArray event0 = result.getArray(0);
         System.out.println(String.format("[]"));
         ColumnarArray event1 = result.getArray(1);
-        System.out.println(String.format("[%d]", event1.getInt(0)));
+        System.out.println(String.format("[%d]", event1.getLong(0)));
         ColumnarArray event2 = result.getArray(2);
-        System.out.println(String.format("[%d, %d]", event2.getInt(0), event2.getInt(1)));
+        System.out.println(String.format("[%d, %d]", event2.getLong(0), event2.getLong(1)));
         ColumnarArray event3 = result.getArray(3);
         ColumnarArray event4 = result.getArray(4);
         ColumnarArray event5 = result.getArray(5);

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -48,7 +48,30 @@ import edu.vanderbilt.accre.laurelin.spark_ttree.TTreeColumnVector;
 
 public class TTreeDataSourceUnitTest {
     @Test
-    public void testIntegers() throws IOException {
+    public void testInt32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("int")), SimpleType.dtypeFromString("int"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        System.out.println(String.format("[]"));
+        ColumnarArray event1 = result.getArray(1);
+        System.out.println(String.format("[%d]", event1.getInt(0)));
+        ColumnarArray event2 = result.getArray(2);
+        System.out.println(String.format("[%d, %d]", event2.getInt(0), event2.getInt(1)));
+        ColumnarArray event3 = result.getArray(3);
+        ColumnarArray event4 = result.getArray(4);
+        ColumnarArray event5 = result.getArray(5);
+        ColumnarArray event6 = result.getArray(6);
+        ColumnarArray event7 = result.getArray(7);
+        ColumnarArray event8 = result.getArray(8);
+    }
+
+    @Test
+    public void testInt64() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
         TBranch branch = tree.getBranches("SliceI64").get(0);

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -11,23 +11,35 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
+import org.junit.Test;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.reader.InputPartition;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.apache.spark.sql.types.IntegerType;
-import org.junit.Test;
+import org.apache.spark.sql.vectorized.ColumnVector;
 
+import edu.vanderbilt.accre.laurelin.array.ArrayBuilder;
+import edu.vanderbilt.accre.laurelin.Cache;
+import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
 import edu.vanderbilt.accre.laurelin.Root;
+import edu.vanderbilt.accre.laurelin.root_proxy.TBranch;
+import edu.vanderbilt.accre.laurelin.root_proxy.TFile;
+import edu.vanderbilt.accre.laurelin.root_proxy.TTree;
 import edu.vanderbilt.accre.laurelin.Root.TTreeDataSourceV2Reader;
 import edu.vanderbilt.accre.laurelin.spark_ttree.ArrayColumnVector;
+import edu.vanderbilt.accre.laurelin.spark_ttree.SlimTBranch;
 
 public class TTreeDataSourceUnitTest {
     @Test
@@ -57,10 +69,15 @@ public class TTreeDataSourceUnitTest {
 
     @Test
     public void testLoadNestedDataFrame() {
+        System.setProperty("hadoop.home.dir", "/");
+        SparkSession spark = SparkSession.builder()
+                .master("local[*]")
+                .appName("test").getOrCreate();
         Dataset<Row> df = spark
                 .read()
                 .format("edu.vanderbilt.accre.laurelin.Root")
-                .option("tree",  "Events")
+                .option("tree", "Events")
+                .option("threadCount", "1")
                 .load("testdata/all-types.root");
         df.printSchema();
         df.select("ScalarI32").show();


### PR DESCRIPTION
I'm going to make sure that the less-symmetric data in "all-types.root" can be read properly. Although I'm testing it in pure Java, it should fix the problems you've been seeing in Spark with fixed-width and variable-width arrays.