### PR TITLE
Handle unsigned integral types

### DIFF
--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/ArrayBuilder.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/ArrayBuilder.java
@@ -200,16 +200,18 @@ public class ArrayBuilder {
             }
 
             RawArray basketdata = getbasket.dataWithoutKey(i);
+
             Array source = null;
             int border = basketkeys[i].fLast - basketkeys[i].fKeylen;
 
             if (basketkeys[i].fObjlen == border) {
+                basketdata = interpretation.convertBufferDiskToMemory(basketdata);
                 source = interpretation.fromroot(basketdata, null, local_entrystart, local_entrystop);
             } else {
                 RawArray content = basketdata.slice(0, border);
                 PrimitiveArray.Int4 byteoffsets = new PrimitiveArray.Int4(basketdata.slice(border + 4, basketkeys[i].fObjlen)).add(true, -basketkeys[i].fKeylen);
                 byteoffsets.put(byteoffsets.length() - 1, border);
-                source = interpretation.fromroot(basketdata, byteoffsets, local_entrystart, local_entrystop);
+                source = interpretation.fromroot(content, byteoffsets, local_entrystart, local_entrystop);
             }
 
             int expecteditems = basket_itemoffset[j + 1] - basket_itemoffset[j];

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/ArrayBuilder.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/ArrayBuilder.java
@@ -211,6 +211,8 @@ public class ArrayBuilder {
                 RawArray content = basketdata.slice(0, border);
                 PrimitiveArray.Int4 byteoffsets = new PrimitiveArray.Int4(basketdata.slice(border + 4, basketkeys[i].fObjlen)).add(true, -basketkeys[i].fKeylen);
                 byteoffsets.put(byteoffsets.length() - 1, border);
+                content = interpretation.subarray().convertBufferDiskToMemory(content);
+                byteoffsets = interpretation.subarray().convertOffsetDiskToMemory(byteoffsets);
                 source = interpretation.fromroot(content, byteoffsets, local_entrystart, local_entrystop);
             }
 

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -114,7 +114,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Bool(byte[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.BOOL), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.put(data, 0, data.length);
         }
@@ -177,7 +177,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Int1(byte[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT1), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             //this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.put(data, 0, data.length);
         }
@@ -240,7 +240,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Int2(short[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT2), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.asShortBuffer().put(data, 0, data.length);
         }
@@ -303,7 +303,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Int4(int[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT4), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.asIntBuffer().put(data, 0, data.length);
         }
@@ -387,7 +387,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Int8(long[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT8), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.asLongBuffer().put(data, 0, data.length);
         }
@@ -450,7 +450,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Float4(float[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.FLOAT4), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.asFloatBuffer().put(data, 0, data.length);
         }
@@ -513,7 +513,7 @@ public abstract class PrimitiveArray extends Array {
 
         public Float8(double[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.FLOAT8), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.memory_itemsize());
             this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             this.buffer.asDoubleBuffer().put(data, 0, data.length);
         }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -13,25 +13,25 @@ import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
 import edu.vanderbilt.accre.laurelin.interpretation.Interpretation;
 
 public abstract class PrimitiveArray extends Array {
-    ByteBuffer buffer;
+    ByteBuffer disk_buffer;
 
     PrimitiveArray(Interpretation interpretation, int length) {
         super(interpretation, length);
-        this.buffer = ByteBuffer.allocate(length * ((interpretation == null) ? 1 : ((AsDtype)interpretation).itemsize() * ((AsDtype)interpretation).multiplicity()));
+        this.disk_buffer = ByteBuffer.allocate(length * ((interpretation == null) ? 1 : ((AsDtype)interpretation).disk_itemsize() * ((AsDtype)interpretation).multiplicity()));
     }
 
     PrimitiveArray(Interpretation interpretation, RawArray rawarray) {
-        super(interpretation, rawarray.length() / ((interpretation == null) ? 1 : ((AsDtype)interpretation).itemsize() * ((AsDtype)interpretation).multiplicity()));
-        this.buffer = rawarray.raw();
+        super(interpretation, rawarray.length() / ((interpretation == null) ? 1 : ((AsDtype)interpretation).disk_itemsize() * ((AsDtype)interpretation).multiplicity()));
+        this.disk_buffer = rawarray.raw();
     }
 
     protected PrimitiveArray(Interpretation interpretation, ByteBuffer buffer) {
-        super(interpretation, (buffer.limit() - buffer.position()) / ((interpretation == null) ? 1 : ((AsDtype)interpretation).itemsize() * ((AsDtype)interpretation).multiplicity()));
-        this.buffer = buffer;
+        super(interpretation, (buffer.limit() - buffer.position()) / ((interpretation == null) ? 1 : ((AsDtype)interpretation).disk_itemsize() * ((AsDtype)interpretation).multiplicity()));
+        this.disk_buffer = buffer;
     }
 
-    public int itemsize() {
-        return ((AsDtype)interpretation).itemsize();
+    public int disk_itemsize() {
+        return ((AsDtype)interpretation).disk_itemsize();
     }
 
     public int multiplicity() {
@@ -43,16 +43,16 @@ public abstract class PrimitiveArray extends Array {
     }
 
     public void copyitems(PrimitiveArray source, int itemstart, int itemstop) {
-        int bytestart = itemstart * this.itemsize();
-        int bytestop = itemstop * this.itemsize();
+        int bytestart = itemstart * this.disk_itemsize();
+        int bytestop = itemstop * this.disk_itemsize();
         /*
          * This code takes advantage of the fact that tmp and this.buffer share
          * the same backing array after duplicate()
          */
-        ByteBuffer tmp = this.buffer.duplicate();
+        ByteBuffer tmp = this.disk_buffer.duplicate();
         tmp.position(bytestart);
         tmp.limit(bytestop);
-        ByteBuffer srctmp = source.buffer.duplicate();
+        ByteBuffer srctmp = source.disk_buffer.duplicate();
         srctmp.position(0);
         tmp.put(srctmp);
     }
@@ -60,20 +60,20 @@ public abstract class PrimitiveArray extends Array {
     @Override
     public Array clip(int start, int stop) {
         int mult = this.multiplicity();
-        int bytestart = start * mult * this.itemsize();
-        int bytestop = stop * mult * this.itemsize();
-        ByteBuffer out = this.buffer.duplicate();
+        int bytestart = start * mult * this.disk_itemsize();
+        int bytestop = stop * mult * this.disk_itemsize();
+        ByteBuffer out = this.disk_buffer.duplicate();
         out.position(bytestart);
         out.limit(bytestop);
         return this.make(out);
     }
 
     public RawArray rawarray() {
-        return new RawArray(this.buffer);
+        return new RawArray(this.disk_buffer);
     }
 
     protected ByteBuffer raw() {
-        return this.buffer;
+        return this.disk_buffer;
     }
 
     protected abstract Array make(ByteBuffer out);
@@ -110,15 +110,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Bool(byte[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.BOOL), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.put(data, 0, data.length);
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            ByteBuffer buf = this.buffer.duplicate();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer buf = this.disk_buffer.duplicate();
             byte[] out = new byte[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -131,11 +131,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Bool(this.interpretation.subarray(), this.buffer);
+            return new Bool(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public boolean toBoolean(int index) {
-            return (this.buffer.get(index) != 0);
+            return (this.disk_buffer.get(index) != 0);
         }
 
         @Override
@@ -173,15 +173,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int1(byte[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT1), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
             //this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.put(data, 0, data.length);
+            this.disk_buffer.put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            ByteBuffer buf = this.buffer.duplicate();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer buf = this.disk_buffer.duplicate();
             byte[] out = new byte[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -194,11 +194,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int1(this.interpretation.subarray(), this.buffer);
+            return new Int1(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public byte toByte(int index) {
-            return this.buffer.get(this.buffer.position() + index);
+            return this.disk_buffer.get(this.disk_buffer.position() + index);
         }
 
         @Override
@@ -236,15 +236,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int2(short[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT2), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.asShortBuffer().put(data, 0, data.length);
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.asShortBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            ShortBuffer buf = this.buffer.asShortBuffer();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            ShortBuffer buf = this.disk_buffer.asShortBuffer();
             short[] out = new short[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -257,11 +257,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int2(this.interpretation.subarray(), this.buffer);
+            return new Int2(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public short toShort(int index) {
-            return this.buffer.asShortBuffer().get(index);
+            return this.disk_buffer.asShortBuffer().get(index);
         }
 
         @Override
@@ -299,15 +299,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int4(int[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT4), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.asIntBuffer().put(data, 0, data.length);
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.asIntBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            IntBuffer buf = this.buffer.asIntBuffer();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            IntBuffer buf = this.disk_buffer.asIntBuffer();
             int[] out = new int[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -320,11 +320,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int4(this.interpretation.subarray(), this.buffer);
+            return new Int4(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public int toInt(int index) {
-            return this.buffer.asIntBuffer().get(index);
+            return this.disk_buffer.asIntBuffer().get(index);
         }
 
         @Override
@@ -335,9 +335,9 @@ public abstract class PrimitiveArray extends Array {
         public Int4 add(boolean bigEndian, int value) {
             ByteBuffer out = ByteBuffer.allocate(length * 4);
             out.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             IntBuffer outint = out.asIntBuffer();
-            IntBuffer thisint = this.buffer.asIntBuffer();
+            IntBuffer thisint = this.disk_buffer.asIntBuffer();
             for (int i = 0;  i < this.length;  i++) {
                 outint.put(i, thisint.get(i) + value);
             }
@@ -345,11 +345,11 @@ public abstract class PrimitiveArray extends Array {
         }
 
         public int get(int i) {
-            return this.buffer.getInt(i * 4);
+            return this.disk_buffer.getInt(i * 4);
         }
 
         public void put(int i, int value) {
-            this.buffer.putInt(i * 4, value);
+            this.disk_buffer.putInt(i * 4, value);
         }
 
     }
@@ -383,15 +383,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int8(long[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT8), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.asLongBuffer().put(data, 0, data.length);
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.asLongBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            LongBuffer buf = this.buffer.asLongBuffer();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            LongBuffer buf = this.disk_buffer.asLongBuffer();
             long[] out = new long[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -404,11 +404,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int8(this.interpretation.subarray(), this.buffer);
+            return new Int8(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public long toLong(int index) {
-            return this.buffer.asLongBuffer().get(index);
+            return this.disk_buffer.asLongBuffer().get(index);
         }
 
         @Override
@@ -446,15 +446,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Float4(float[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.FLOAT4), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.asFloatBuffer().put(data, 0, data.length);
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.asFloatBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            FloatBuffer buf = this.buffer.asFloatBuffer();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            FloatBuffer buf = this.disk_buffer.asFloatBuffer();
             float[] out = new float[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -467,11 +467,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Float4(this.interpretation.subarray(), this.buffer);
+            return new Float4(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public float toFloat(int index) {
-            return this.buffer.asFloatBuffer().get(index);
+            return this.disk_buffer.asFloatBuffer().get(index);
         }
 
         @Override
@@ -509,15 +509,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Float8(double[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.FLOAT8), data.length);
-            this.buffer = ByteBuffer.allocate(data.length * this.itemsize());
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.buffer.asDoubleBuffer().put(data, 0, data.length);
+            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.disk_buffer.asDoubleBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            DoubleBuffer buf = this.buffer.asDoubleBuffer();
+            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            DoubleBuffer buf = this.disk_buffer.asDoubleBuffer();
             double[] out = new double[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -530,11 +530,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Float8(this.interpretation.subarray(), this.buffer);
+            return new Float8(this.interpretation.subarray(), this.disk_buffer);
         }
 
         public double toDouble(int index) {
-            return this.buffer.asDoubleBuffer().get(index);
+            return this.disk_buffer.asDoubleBuffer().get(index);
         }
 
         @Override

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -13,21 +13,21 @@ import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
 import edu.vanderbilt.accre.laurelin.interpretation.Interpretation;
 
 public abstract class PrimitiveArray extends Array {
-    ByteBuffer disk_buffer;
+    ByteBuffer buffer;
 
     PrimitiveArray(Interpretation interpretation, int length) {
         super(interpretation, length);
-        this.disk_buffer = ByteBuffer.allocate(length * ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
+        this.buffer = ByteBuffer.allocate(length * ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
     }
 
     PrimitiveArray(Interpretation interpretation, RawArray rawarray) {
         super(interpretation, rawarray.length() / ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
-        this.disk_buffer = rawarray.raw();
+        this.buffer = rawarray.raw();
     }
 
     protected PrimitiveArray(Interpretation interpretation, ByteBuffer buffer) {
         super(interpretation, (buffer.limit() - buffer.position()) / ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
-        this.disk_buffer = buffer;
+        this.buffer = buffer;
     }
 
     public int disk_itemsize() {
@@ -53,10 +53,10 @@ public abstract class PrimitiveArray extends Array {
          * This code takes advantage of the fact that tmp and this.buffer share
          * the same backing array after duplicate()
          */
-        ByteBuffer tmp = this.disk_buffer.duplicate();
+        ByteBuffer tmp = this.buffer.duplicate();
         tmp.position(bytestart);
         tmp.limit(bytestop);
-        ByteBuffer srctmp = source.disk_buffer.duplicate();
+        ByteBuffer srctmp = source.buffer.duplicate();
         srctmp.position(0);
         tmp.put(srctmp);
     }
@@ -66,18 +66,18 @@ public abstract class PrimitiveArray extends Array {
         int mult = this.multiplicity();
         int bytestart = start * mult * this.memory_itemsize();
         int bytestop = stop * mult * this.memory_itemsize();
-        ByteBuffer out = this.disk_buffer.duplicate();
+        ByteBuffer out = this.buffer.duplicate();
         out.position(bytestart);
         out.limit(bytestop);
         return this.make(out);
     }
 
     public RawArray rawarray() {
-        return new RawArray(this.disk_buffer);
+        return new RawArray(this.buffer);
     }
 
     protected ByteBuffer raw() {
-        return this.disk_buffer;
+        return this.buffer;
     }
 
     protected abstract Array make(ByteBuffer out);
@@ -114,15 +114,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Bool(byte[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.BOOL), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.put(data, 0, data.length);
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            ByteBuffer buf = this.disk_buffer.duplicate();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer buf = this.buffer.duplicate();
             byte[] out = new byte[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -135,11 +135,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Bool(this.interpretation.subarray(), this.disk_buffer);
+            return new Bool(this.interpretation.subarray(), this.buffer);
         }
 
         public boolean toBoolean(int index) {
-            return (this.disk_buffer.get(index) != 0);
+            return (this.buffer.get(index) != 0);
         }
 
         @Override
@@ -177,15 +177,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int1(byte[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT1), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
             //this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.put(data, 0, data.length);
+            this.buffer.put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            ByteBuffer buf = this.disk_buffer.duplicate();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer buf = this.buffer.duplicate();
             byte[] out = new byte[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -198,11 +198,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int1(this.interpretation.subarray(), this.disk_buffer);
+            return new Int1(this.interpretation.subarray(), this.buffer);
         }
 
         public byte toByte(int index) {
-            return this.disk_buffer.get(this.disk_buffer.position() + index);
+            return this.buffer.get(this.buffer.position() + index);
         }
 
         @Override
@@ -240,15 +240,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int2(short[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT2), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.asShortBuffer().put(data, 0, data.length);
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.asShortBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            ShortBuffer buf = this.disk_buffer.asShortBuffer();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            ShortBuffer buf = this.buffer.asShortBuffer();
             short[] out = new short[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -261,11 +261,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int2(this.interpretation.subarray(), this.disk_buffer);
+            return new Int2(this.interpretation.subarray(), this.buffer);
         }
 
         public short toShort(int index) {
-            return this.disk_buffer.asShortBuffer().get(index);
+            return this.buffer.asShortBuffer().get(index);
         }
 
         @Override
@@ -303,15 +303,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int4(int[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT4), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.asIntBuffer().put(data, 0, data.length);
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.asIntBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            IntBuffer buf = this.disk_buffer.asIntBuffer();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            IntBuffer buf = this.buffer.asIntBuffer();
             int[] out = new int[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -324,11 +324,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int4(this.interpretation.subarray(), this.disk_buffer);
+            return new Int4(this.interpretation.subarray(), this.buffer);
         }
 
         public int toInt(int index) {
-            return this.disk_buffer.asIntBuffer().get(index);
+            return this.buffer.asIntBuffer().get(index);
         }
 
         @Override
@@ -339,9 +339,9 @@ public abstract class PrimitiveArray extends Array {
         public Int4 add(boolean bigEndian, int value) {
             ByteBuffer out = ByteBuffer.allocate(length * 4);
             out.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
             IntBuffer outint = out.asIntBuffer();
-            IntBuffer thisint = this.disk_buffer.asIntBuffer();
+            IntBuffer thisint = this.buffer.asIntBuffer();
             for (int i = 0;  i < this.length;  i++) {
                 outint.put(i, thisint.get(i) + value);
             }
@@ -349,11 +349,11 @@ public abstract class PrimitiveArray extends Array {
         }
 
         public int get(int i) {
-            return this.disk_buffer.getInt(i * 4);
+            return this.buffer.getInt(i * 4);
         }
 
         public void put(int i, int value) {
-            this.disk_buffer.putInt(i * 4, value);
+            this.buffer.putInt(i * 4, value);
         }
 
     }
@@ -387,15 +387,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Int8(long[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.INT8), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.asLongBuffer().put(data, 0, data.length);
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.asLongBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            LongBuffer buf = this.disk_buffer.asLongBuffer();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            LongBuffer buf = this.buffer.asLongBuffer();
             long[] out = new long[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -408,11 +408,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Int8(this.interpretation.subarray(), this.disk_buffer);
+            return new Int8(this.interpretation.subarray(), this.buffer);
         }
 
         public long toLong(int index) {
-            return this.disk_buffer.asLongBuffer().get(index);
+            return this.buffer.asLongBuffer().get(index);
         }
 
         @Override
@@ -450,15 +450,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Float4(float[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.FLOAT4), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.asFloatBuffer().put(data, 0, data.length);
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.asFloatBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            FloatBuffer buf = this.disk_buffer.asFloatBuffer();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            FloatBuffer buf = this.buffer.asFloatBuffer();
             float[] out = new float[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -471,11 +471,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Float4(this.interpretation.subarray(), this.disk_buffer);
+            return new Float4(this.interpretation.subarray(), this.buffer);
         }
 
         public float toFloat(int index) {
-            return this.disk_buffer.asFloatBuffer().get(index);
+            return this.buffer.asFloatBuffer().get(index);
         }
 
         @Override
@@ -513,15 +513,15 @@ public abstract class PrimitiveArray extends Array {
 
         public Float8(double[] data, boolean bigEndian) {
             super(new AsDtype(AsDtype.Dtype.FLOAT8), data.length);
-            this.disk_buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            this.disk_buffer.asDoubleBuffer().put(data, 0, data.length);
+            this.buffer = ByteBuffer.allocate(data.length * this.disk_itemsize());
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            this.buffer.asDoubleBuffer().put(data, 0, data.length);
         }
 
         @Override
         public Object toArray(boolean bigEndian) {
-            this.disk_buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-            DoubleBuffer buf = this.disk_buffer.asDoubleBuffer();
+            this.buffer.order(bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+            DoubleBuffer buf = this.buffer.asDoubleBuffer();
             double[] out = new double[buf.limit() - buf.position()];
             buf.get(out);
             return out;
@@ -534,11 +534,11 @@ public abstract class PrimitiveArray extends Array {
 
         @Override
         public Array subarray() {
-            return new Float8(this.interpretation.subarray(), this.disk_buffer);
+            return new Float8(this.interpretation.subarray(), this.buffer);
         }
 
         public double toDouble(int index) {
-            return this.disk_buffer.asDoubleBuffer().get(index);
+            return this.buffer.asDoubleBuffer().get(index);
         }
 
         @Override

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/PrimitiveArray.java
@@ -17,21 +17,25 @@ public abstract class PrimitiveArray extends Array {
 
     PrimitiveArray(Interpretation interpretation, int length) {
         super(interpretation, length);
-        this.disk_buffer = ByteBuffer.allocate(length * ((interpretation == null) ? 1 : ((AsDtype)interpretation).disk_itemsize() * ((AsDtype)interpretation).multiplicity()));
+        this.disk_buffer = ByteBuffer.allocate(length * ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
     }
 
     PrimitiveArray(Interpretation interpretation, RawArray rawarray) {
-        super(interpretation, rawarray.length() / ((interpretation == null) ? 1 : ((AsDtype)interpretation).disk_itemsize() * ((AsDtype)interpretation).multiplicity()));
+        super(interpretation, rawarray.length() / ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
         this.disk_buffer = rawarray.raw();
     }
 
     protected PrimitiveArray(Interpretation interpretation, ByteBuffer buffer) {
-        super(interpretation, (buffer.limit() - buffer.position()) / ((interpretation == null) ? 1 : ((AsDtype)interpretation).disk_itemsize() * ((AsDtype)interpretation).multiplicity()));
+        super(interpretation, (buffer.limit() - buffer.position()) / ((interpretation == null) ? 1 : ((AsDtype)interpretation).memory_itemsize() * ((AsDtype)interpretation).multiplicity()));
         this.disk_buffer = buffer;
     }
 
     public int disk_itemsize() {
         return ((AsDtype)interpretation).disk_itemsize();
+    }
+
+    public int memory_itemsize() {
+        return ((AsDtype)interpretation).memory_itemsize();
     }
 
     public int multiplicity() {
@@ -43,8 +47,8 @@ public abstract class PrimitiveArray extends Array {
     }
 
     public void copyitems(PrimitiveArray source, int itemstart, int itemstop) {
-        int bytestart = itemstart * this.disk_itemsize();
-        int bytestop = itemstop * this.disk_itemsize();
+        int bytestart = itemstart * this.memory_itemsize();
+        int bytestop = itemstop * this.memory_itemsize();
         /*
          * This code takes advantage of the fact that tmp and this.buffer share
          * the same backing array after duplicate()
@@ -60,8 +64,8 @@ public abstract class PrimitiveArray extends Array {
     @Override
     public Array clip(int start, int stop) {
         int mult = this.multiplicity();
-        int bytestart = start * mult * this.disk_itemsize();
-        int bytestop = stop * mult * this.disk_itemsize();
+        int bytestart = start * mult * this.memory_itemsize();
+        int bytestop = stop * mult * this.memory_itemsize();
         ByteBuffer out = this.disk_buffer.duplicate();
         out.position(bytestart);
         out.limit(bytestop);

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
@@ -5,17 +5,17 @@ import java.nio.ByteBuffer;
 public class RawArray extends PrimitiveArray {
     RawArray(int length) {
         super(null, length);
-        this.disk_buffer = ByteBuffer.allocate(length);
+        this.buffer = ByteBuffer.allocate(length);
     }
 
     RawArray(RawArray rawarray) {
         super(null, rawarray.length());
-        this.disk_buffer = rawarray.raw();
+        this.buffer = rawarray.raw();
     }
 
     public RawArray(ByteBuffer buffer) {
         super(null, buffer.limit());
-        this.disk_buffer = buffer;
+        this.buffer = buffer;
     }
 
     @Override
@@ -29,7 +29,7 @@ public class RawArray extends PrimitiveArray {
     }
 
     public RawArray slice(int start, int stop) {
-        ByteBuffer tmp = disk_buffer.duplicate();
+        ByteBuffer tmp = buffer.duplicate();
         tmp.position(start);
         tmp.limit(stop);
         return new RawArray(tmp.slice());
@@ -37,7 +37,7 @@ public class RawArray extends PrimitiveArray {
 
     @Override
     public Array clip(int start, int stop) {
-        ByteBuffer out = this.disk_buffer.duplicate();
+        ByteBuffer out = this.buffer.duplicate();
         out.position(start);
         out.limit(stop);
         return this.make(out);
@@ -45,21 +45,21 @@ public class RawArray extends PrimitiveArray {
 
     public RawArray compact(PrimitiveArray.Int4 byteoffsets, int skipbytes, int local_entrystart, int local_entrystop) {
         if (skipbytes == 0) {
-            ByteBuffer out = this.disk_buffer.duplicate();
+            ByteBuffer out = this.buffer.duplicate();
             out.position(byteoffsets.get(local_entrystart));
             out.limit(byteoffsets.get(local_entrystop));
             return new RawArray(out);
         } else {
             ByteBuffer out = ByteBuffer.allocate(byteoffsets.get(local_entrystop) - byteoffsets.get(local_entrystart) - skipbytes * (local_entrystop - local_entrystart));
-            this.disk_buffer.position(0);
+            this.buffer.position(0);
             for (int i = local_entrystart;  i < local_entrystop;  i++) {
                 int start = byteoffsets.get(i) + skipbytes;
                 int count = byteoffsets.get(i + 1) - start;
                 byte[] copy = new byte[count];
-                this.disk_buffer.get(copy);
+                this.buffer.get(copy);
                 out.put(copy);
             }
-            this.disk_buffer.position(0);
+            this.buffer.position(0);
             out.position(0);
             return new RawArray(out);
         }
@@ -67,8 +67,8 @@ public class RawArray extends PrimitiveArray {
 
     @Override
     public Object toArray(boolean bigEndian) {
-        byte[] out = new byte[this.disk_buffer.limit() - this.disk_buffer.position()];
-        this.disk_buffer.get(out);
+        byte[] out = new byte[this.buffer.limit() - this.buffer.position()];
+        this.buffer.get(out);
         return out;
     }
 
@@ -83,18 +83,18 @@ public class RawArray extends PrimitiveArray {
     }
 
     public byte getByte(int i) {
-        return this.disk_buffer.get(i);
+        return this.buffer.get(i);
     }
 
     public byte[] getLongBytes(int i) {
         byte[] ret = new byte[8];
-        int pos = this.disk_buffer.position();
-        this.disk_buffer.get(ret, i, 8);
-        this.disk_buffer.position(pos);
+        int pos = this.buffer.position();
+        this.buffer.get(ret, i, 8);
+        this.buffer.position(pos);
         return ret;
     }
 
     public long getLong(int i) {
-        return this.disk_buffer.getLong(i);
+        return this.buffer.getLong(i);
     }
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
@@ -5,21 +5,21 @@ import java.nio.ByteBuffer;
 public class RawArray extends PrimitiveArray {
     RawArray(int length) {
         super(null, length);
-        this.buffer = ByteBuffer.allocate(length);
+        this.disk_buffer = ByteBuffer.allocate(length);
     }
 
     RawArray(RawArray rawarray) {
         super(null, rawarray.length());
-        this.buffer = rawarray.raw();
+        this.disk_buffer = rawarray.raw();
     }
 
     public RawArray(ByteBuffer buffer) {
         super(null, buffer.limit());
-        this.buffer = buffer;
+        this.disk_buffer = buffer;
     }
 
     @Override
-    public int itemsize() {
+    public int disk_itemsize() {
         return 1;
     }
 
@@ -29,7 +29,7 @@ public class RawArray extends PrimitiveArray {
     }
 
     public RawArray slice(int start, int stop) {
-        ByteBuffer tmp = buffer.duplicate();
+        ByteBuffer tmp = disk_buffer.duplicate();
         tmp.position(start);
         tmp.limit(stop);
         return new RawArray(tmp.slice());
@@ -37,7 +37,7 @@ public class RawArray extends PrimitiveArray {
 
     @Override
     public Array clip(int start, int stop) {
-        ByteBuffer out = this.buffer.duplicate();
+        ByteBuffer out = this.disk_buffer.duplicate();
         out.position(start);
         out.limit(stop);
         return this.make(out);
@@ -45,21 +45,21 @@ public class RawArray extends PrimitiveArray {
 
     public RawArray compact(PrimitiveArray.Int4 byteoffsets, int skipbytes, int local_entrystart, int local_entrystop) {
         if (skipbytes == 0) {
-            ByteBuffer out = this.buffer.duplicate();
+            ByteBuffer out = this.disk_buffer.duplicate();
             out.position(byteoffsets.get(local_entrystart));
             out.limit(byteoffsets.get(local_entrystop));
             return new RawArray(out);
         } else {
             ByteBuffer out = ByteBuffer.allocate(byteoffsets.get(local_entrystop) - byteoffsets.get(local_entrystart) - skipbytes * (local_entrystop - local_entrystart));
-            this.buffer.position(0);
+            this.disk_buffer.position(0);
             for (int i = local_entrystart;  i < local_entrystop;  i++) {
                 int start = byteoffsets.get(i) + skipbytes;
                 int count = byteoffsets.get(i + 1) - start;
                 byte[] copy = new byte[count];
-                this.buffer.get(copy);
+                this.disk_buffer.get(copy);
                 out.put(copy);
             }
-            this.buffer.position(0);
+            this.disk_buffer.position(0);
             out.position(0);
             return new RawArray(out);
         }
@@ -67,8 +67,8 @@ public class RawArray extends PrimitiveArray {
 
     @Override
     public Object toArray(boolean bigEndian) {
-        byte[] out = new byte[this.buffer.limit() - this.buffer.position()];
-        this.buffer.get(out);
+        byte[] out = new byte[this.disk_buffer.limit() - this.disk_buffer.position()];
+        this.disk_buffer.get(out);
         return out;
     }
 

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
@@ -81,4 +81,8 @@ public class RawArray extends PrimitiveArray {
     public Array subarray() {
         throw new UnsupportedOperationException("RawArray is not subarrayable");
     }
+
+    public byte getByte(int i) {
+        return this.disk_buffer.get(i);
+    }
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/RawArray.java
@@ -85,4 +85,16 @@ public class RawArray extends PrimitiveArray {
     public byte getByte(int i) {
         return this.disk_buffer.get(i);
     }
+
+    public byte[] getLongBytes(int i) {
+        byte[] ret = new byte[8];
+        int pos = this.disk_buffer.position();
+        this.disk_buffer.get(ret, i, 8);
+        this.disk_buffer.position(pos);
+        return ret;
+    }
+
+    public long getLong(int i) {
+        return this.disk_buffer.getLong(i);
+    }
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
@@ -53,7 +53,7 @@ public class AsDtype implements Interpretation {
     }
 
     @Override
-    public int itemsize() {
+    public int disk_itemsize() {
         switch (this.dtype) {
             case BOOL:
                 return 1;
@@ -71,6 +71,36 @@ public class AsDtype implements Interpretation {
                 return 2;
             case UINT4:
                 return 4;
+            case UINT8:
+                return 8;
+            case FLOAT4:
+                return 4;
+            case FLOAT8:
+                return 8;
+            default:
+                throw new AssertionError("unrecognized dtype");
+        }
+    }
+
+    @Override
+    public int memory_itemsize() {
+        switch (this.dtype) {
+            case BOOL:
+                return 1;
+            case INT1:
+                return 1;
+            case INT2:
+                return 2;
+            case INT4:
+                return 4;
+            case INT8:
+                return 8;
+            case UINT1:
+                return 2;
+            case UINT2:
+                return 4;
+            case UINT4:
+                return 8;
             case UINT8:
                 return 8;
             case FLOAT4:
@@ -114,11 +144,11 @@ public class AsDtype implements Interpretation {
 
     @Override
     public int numitems(int numbytes, int numentries) {
-        if (numbytes % this.itemsize() != 0) {
+        if (numbytes % this.disk_itemsize() != 0) {
             throw new AssertionError(
                     String.format("%d byte buffer does not divide evenly into %s", numbytes, this.dtype.toString()));
         }
-        return numbytes / this.itemsize();
+        return numbytes / this.disk_itemsize();
     }
 
     @Override
@@ -131,7 +161,7 @@ public class AsDtype implements Interpretation {
         if (byteoffsets != null) {
             throw new AssertionError("byteoffsets must be null for AsDtype");
         }
-        int entrysize = this.multiplicity() * this.itemsize();
+        int entrysize = this.multiplicity() * this.disk_itemsize();
         RawArray sliced = bytedata.slice(local_entrystart * entrysize, local_entrystop * entrysize);
         switch (this.dtype) {
             case BOOL:

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
@@ -232,6 +232,7 @@ public class AsDtype implements Interpretation {
 
     @Override
     public RawArray convertBufferDiskToMemory(RawArray source) {
+        ByteBuffer converted;
         switch (this.dtype) {
             case UINT1:
                 /*
@@ -245,11 +246,38 @@ public class AsDtype implements Interpretation {
                  *
                  * ByteBuffers are always initialized to zero
                  */
-                ByteBuffer converted = ByteBuffer.allocate(source.length() * 2);
+                converted = ByteBuffer.allocate(source.length() * 2);
                 for (int i = 0; i < source.length(); i += 1) {
                     converted.put((i * 2) + 1, source.getByte(i));
                 }
                 return new RawArray(converted);
+            default:
+                break;
+        }
+        return source;
+    }
+
+    @Override
+    public PrimitiveArray.Int4 convertOffsetDiskToMemory(PrimitiveArray.Int4 source) {
+        PrimitiveArray.Int4 converted;
+        switch (this.dtype) {
+            case UINT1:
+                /*
+                 * Conveniently both Java and ROOT are big-endian, to convert
+                 * the following unsigned 8-bit int into a signed 16-bit int,
+                 * add zeros like the following
+                 *
+                 * index:  0  1  2  3  4  5  6  7  8  9
+                 * src:   11 22 33 44
+                 * dest:  00 11 00 22 00 33 00 44
+                 *
+                 * ByteBuffers are always initialized to zero
+                 */
+                converted = new PrimitiveArray.Int4(source.length());
+                for (int i = 0; i < source.length(); i += 1) {
+                    converted.put(i, source.get(i) * 2);
+                }
+                return converted;
             default:
                 break;
         }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
@@ -183,7 +183,7 @@ public class AsDtype implements Interpretation {
             case UINT2:
                 return new PrimitiveArray.Int4(this, sliced);
             case UINT4:
-                throw new UnsupportedOperationException("not implemented yet");
+                return new PrimitiveArray.Int8(this, sliced);
             case UINT8:
                 throw new UnsupportedOperationException("not implemented yet");
             case FLOAT4:
@@ -260,7 +260,21 @@ public class AsDtype implements Interpretation {
                 converted = ByteBuffer.allocate(source.length() * 2);
                 for (int i = 0; i < source.length(); i += 2) {
                     converted.put((i * 2) + 2, source.getByte(i));
-                    converted.put((i * 2) + 3, source.getByte(i+1));
+                    converted.put((i * 2) + 3, source.getByte(i + 1));
+                }
+                return new RawArray(converted);
+            case UINT4:
+                /*
+                 * index:  0  1  2  3  4  5  6  7  8  9
+                 * src:   11 22 33 44
+                 * dest:  00 00 11 22 00 00 33 44
+                 */
+                converted = ByteBuffer.allocate(source.length() * 2);
+                for (int i = 0; i < source.length(); i += 4) {
+                    converted.put((i * 2) + 4, source.getByte(i));
+                    converted.put((i * 2) + 5, source.getByte(i + 1));
+                    converted.put((i * 2) + 6, source.getByte(i + 2));
+                    converted.put((i * 2) + 7, source.getByte(i + 3));
                 }
                 return new RawArray(converted);
             default:
@@ -275,6 +289,7 @@ public class AsDtype implements Interpretation {
         switch (this.dtype) {
             case UINT1:
             case UINT2:
+            case UINT4:
                 /*
                  * The offsets are byte-indexed so if we make the type larger,
                  * we need to also re-point the offsets

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsDtype.java
@@ -267,7 +267,7 @@ public class AsDtype implements Interpretation {
                 /*
                  * index:  0  1  2  3  4  5  6  7  8  9
                  * src:   11 22 33 44
-                 * dest:  00 00 11 22 00 00 33 44
+                 * dest:  00 00 00 00 11 22 33 44
                  */
                 converted = ByteBuffer.allocate(source.length() * 2);
                 for (int i = 0; i < source.length(); i += 4) {

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
@@ -55,11 +55,12 @@ public class AsJagged implements Interpretation {
     public Array fromroot(RawArray bytedata, PrimitiveArray.Int4 byteoffsets, int local_entrystart, int local_entrystop) {
         RawArray compact = bytedata.compact(byteoffsets, this.skipbytes, local_entrystart, local_entrystop);
 
-        int innersize = ((AsDtype)this.content).disk_itemsize() * ((AsDtype)this.content).multiplicity();
+        int innersize_memory = ((AsDtype)this.content).memory_itemsize() * ((AsDtype)this.content).multiplicity();
+        int innersize_disk = ((AsDtype)this.content).disk_itemsize() * ((AsDtype)this.content).multiplicity();
         ByteBuffer countsbuf = ByteBuffer.allocate((local_entrystop - local_entrystart) * 4);
         int total = 0;
         for (int i = local_entrystart;  i < local_entrystop;  i++) {
-            int count = (byteoffsets.get(i + 1) - byteoffsets.get(i)) / innersize;
+            int count = (byteoffsets.get(i + 1) - byteoffsets.get(i)) / innersize_disk;
             countsbuf.putInt(count);
             total += count;
         }
@@ -111,6 +112,12 @@ public class AsJagged implements Interpretation {
     @Override
     public Interpretation subarray() {
         return this.content();
+    }
+
+    @Override
+    public RawArray convertBufferDiskToMemory(RawArray source) {
+        // TODO Auto-generated method stub
+        return null;
     }
 
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
@@ -57,7 +57,6 @@ public class AsJagged implements Interpretation {
         RawArray compact = bytedata.compact(byteoffsets, this.skipbytes, local_entrystart, local_entrystop);
 
         int innersize_memory = ((AsDtype)this.content).memory_itemsize() * ((AsDtype)this.content).multiplicity();
-        int innersize_disk = ((AsDtype)this.content).disk_itemsize() * ((AsDtype)this.content).multiplicity();
         ByteBuffer countsbuf = ByteBuffer.allocate((local_entrystop - local_entrystart) * 4);
         int total = 0;
         for (int i = local_entrystart;  i < local_entrystop;  i++) {

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
@@ -27,8 +27,13 @@ public class AsJagged implements Interpretation {
     }
 
     @Override
-    public int itemsize() {
-        return this.content.itemsize();
+    public int disk_itemsize() {
+        return this.content.disk_itemsize();
+    }
+
+    @Override
+    public int memory_itemsize() {
+        return this.content.memory_itemsize();
     }
 
     @Override
@@ -50,7 +55,7 @@ public class AsJagged implements Interpretation {
     public Array fromroot(RawArray bytedata, PrimitiveArray.Int4 byteoffsets, int local_entrystart, int local_entrystop) {
         RawArray compact = bytedata.compact(byteoffsets, this.skipbytes, local_entrystart, local_entrystop);
 
-        int innersize = ((AsDtype)this.content).itemsize() * ((AsDtype)this.content).multiplicity();
+        int innersize = ((AsDtype)this.content).disk_itemsize() * ((AsDtype)this.content).multiplicity();
         ByteBuffer countsbuf = ByteBuffer.allocate((local_entrystop - local_entrystart) * 4);
         int total = 0;
         for (int i = local_entrystart;  i < local_entrystop;  i++) {

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/AsJagged.java
@@ -6,6 +6,7 @@ import edu.vanderbilt.accre.laurelin.array.Array;
 import edu.vanderbilt.accre.laurelin.array.JaggedArray;
 import edu.vanderbilt.accre.laurelin.array.JaggedArrayPrep;
 import edu.vanderbilt.accre.laurelin.array.PrimitiveArray;
+import edu.vanderbilt.accre.laurelin.array.PrimitiveArray.Int4;
 import edu.vanderbilt.accre.laurelin.array.RawArray;
 
 public class AsJagged implements Interpretation {
@@ -60,7 +61,7 @@ public class AsJagged implements Interpretation {
         ByteBuffer countsbuf = ByteBuffer.allocate((local_entrystop - local_entrystart) * 4);
         int total = 0;
         for (int i = local_entrystart;  i < local_entrystop;  i++) {
-            int count = (byteoffsets.get(i + 1) - byteoffsets.get(i)) / innersize_disk;
+            int count = (byteoffsets.get(i + 1) - byteoffsets.get(i)) / innersize_memory;
             countsbuf.putInt(count);
             total += count;
         }
@@ -116,8 +117,12 @@ public class AsJagged implements Interpretation {
 
     @Override
     public RawArray convertBufferDiskToMemory(RawArray source) {
-        // TODO Auto-generated method stub
-        return null;
+        return subarray().convertBufferDiskToMemory(source);
+    }
+
+    @Override
+    public Int4 convertOffsetDiskToMemory(Int4 source) {
+        throw new RuntimeException("Bad offset");
     }
 
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/Interpretation.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/Interpretation.java
@@ -26,4 +26,6 @@ public interface Interpretation {
     public Array finalize(Array destination);
 
     public Interpretation subarray();
+
+    public RawArray convertBufferDiskToMemory(RawArray source);
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/Interpretation.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/Interpretation.java
@@ -2,6 +2,7 @@ package edu.vanderbilt.accre.laurelin.interpretation;
 
 import edu.vanderbilt.accre.laurelin.array.Array;
 import edu.vanderbilt.accre.laurelin.array.PrimitiveArray;
+import edu.vanderbilt.accre.laurelin.array.PrimitiveArray.Int4;
 import edu.vanderbilt.accre.laurelin.array.RawArray;
 
 public interface Interpretation {
@@ -28,4 +29,6 @@ public interface Interpretation {
     public Interpretation subarray();
 
     public RawArray convertBufferDiskToMemory(RawArray source);
+
+    public Int4 convertOffsetDiskToMemory(Int4 source);
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/Interpretation.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/interpretation/Interpretation.java
@@ -5,7 +5,9 @@ import edu.vanderbilt.accre.laurelin.array.PrimitiveArray;
 import edu.vanderbilt.accre.laurelin.array.RawArray;
 
 public interface Interpretation {
-    public int itemsize();
+    public int disk_itemsize();
+
+    public int memory_itemsize();
 
     public Array empty();
 

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -11,42 +11,34 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Arrays;
 
-import org.junit.Test;
-
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.reader.InputPartition;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.ByteType;
-import org.apache.spark.sql.types.ShortType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DoubleType;
+import org.apache.spark.sql.types.FloatType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
-import org.apache.spark.sql.types.FloatType;
-import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.apache.spark.sql.vectorized.ColumnVector;
+import org.junit.Test;
 
-import edu.vanderbilt.accre.laurelin.array.ArrayBuilder;
 import edu.vanderbilt.accre.laurelin.Cache;
-import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
 import edu.vanderbilt.accre.laurelin.Root;
+import edu.vanderbilt.accre.laurelin.Root.TTreeDataSourceV2Reader;
 import edu.vanderbilt.accre.laurelin.root_proxy.SimpleType;
 import edu.vanderbilt.accre.laurelin.root_proxy.TBranch;
 import edu.vanderbilt.accre.laurelin.root_proxy.TFile;
 import edu.vanderbilt.accre.laurelin.root_proxy.TTree;
-import edu.vanderbilt.accre.laurelin.Root.TTreeDataSourceV2Reader;
-import edu.vanderbilt.accre.laurelin.spark_ttree.ArrayColumnVector;
 import edu.vanderbilt.accre.laurelin.spark_ttree.SlimTBranch;
 import edu.vanderbilt.accre.laurelin.spark_ttree.TTreeColumnVector;
 
@@ -248,6 +240,26 @@ public class TTreeDataSourceUnitTest {
         assertEquals(result.getByte(6), 127);
         assertEquals(result.getByte(7), 126);
         assertEquals(result.getByte(8), 125);
+    }
+
+    @Test
+    public void testScalarUI8() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarUI8").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ShortType(), SimpleType.fromString("uchar"), SimpleType.dtypeFromString("uchar"), cache, 0, 9, slim, null);
+        assertEquals(result.getShort(0), 0);
+        assertEquals(result.getShort(1), 1);
+        assertEquals(result.getShort(2), 2);
+        assertEquals(result.getShort(3), 0);
+        assertEquals(result.getShort(4), 1);
+        assertEquals(result.getShort(5), 2);
+        assertEquals(result.getShort(6), 255);
+        assertEquals(result.getShort(7), 254);
+        assertEquals(result.getShort(8), 253);
     }
 
     @Test
@@ -696,7 +708,7 @@ public class TTreeDataSourceUnitTest {
 
         TTreeColumnVector result = new TTreeColumnVector(new FloatType(), SimpleType.fromString("float"), SimpleType.dtypeFromString("float"), cache, 0, 100, slim, null);
         for (int i = 0;  i < 100;  i++) {
-            assertEquals(result.getFloat(i), (float)i, 0.0001);
+            assertEquals(result.getFloat(i), i, 0.0001);
         }
     }
 
@@ -713,7 +725,7 @@ public class TTreeDataSourceUnitTest {
             ColumnarArray event = result.getArray(i);
             assertEquals(event.numElements(), 10);
             for (int j = 0;  j < 10;  j++) {
-                assertEquals(result.getFloat(i), (float)i, 0.0001);
+                assertEquals(result.getFloat(i), i, 0.0001);
             }
         }
     }
@@ -731,7 +743,7 @@ public class TTreeDataSourceUnitTest {
             ColumnarArray event = result.getArray(i);
             assertEquals(event.numElements(), i % 10);
             for (int j = 0;  j < i % 10;  j++) {
-                assertEquals(result.getFloat(i), (float)i, 0.0001);
+                assertEquals(result.getFloat(i), i, 0.0001);
             }
         }
     }
@@ -746,7 +758,7 @@ public class TTreeDataSourceUnitTest {
 
         TTreeColumnVector result = new TTreeColumnVector(new DoubleType(), SimpleType.fromString("double"), SimpleType.dtypeFromString("double"), cache, 0, 100, slim, null);
         for (int i = 0;  i < 100;  i++) {
-            assertEquals(result.getDouble(i), (double)i, 0.0001);
+            assertEquals(result.getDouble(i), i, 0.0001);
         }
     }
 
@@ -763,7 +775,7 @@ public class TTreeDataSourceUnitTest {
             ColumnarArray event = result.getArray(i);
             assertEquals(event.numElements(), 10);
             for (int j = 0;  j < 10;  j++) {
-                assertEquals(result.getDouble(i), (double)i, 0.0001);
+                assertEquals(result.getDouble(i), i, 0.0001);
             }
         }
     }
@@ -781,7 +793,7 @@ public class TTreeDataSourceUnitTest {
             ColumnarArray event = result.getArray(i);
             assertEquals(event.numElements(), i % 10);
             for (int j = 0;  j < i % 10;  j++) {
-                assertEquals(result.getDouble(i), (double)i, 0.0001);
+                assertEquals(result.getDouble(i), i, 0.0001);
             }
         }
     }

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -319,6 +319,62 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testArrayUI8() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayUI8").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ShortType(), false), new SimpleType.ArrayType(SimpleType.fromString("uchar")), SimpleType.dtypeFromString("uchar"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getShort(0), 0);
+        assertEquals(event0.getShort(1), 0);
+        assertEquals(event0.getShort(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getShort(0), 1);
+        assertEquals(event1.getShort(1), 1);
+        assertEquals(event1.getShort(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getShort(0), 2);
+        assertEquals(event2.getShort(1), 2);
+        assertEquals(event2.getShort(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getShort(0), 0);
+        assertEquals(event3.getShort(1), 0);
+        assertEquals(event3.getShort(2), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getShort(0), 1);
+        assertEquals(event4.getShort(1), 1);
+        assertEquals(event4.getShort(2), 1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getShort(0), 2);
+        assertEquals(event5.getShort(1), 2);
+        assertEquals(event5.getShort(2), 2);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getShort(0), 255);
+        assertEquals(event6.getShort(1), 255);
+        assertEquals(event6.getShort(2), 255);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getShort(0), 254);
+        assertEquals(event7.getShort(1), 254);
+        assertEquals(event7.getShort(2), 254);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getShort(0), 253);
+        assertEquals(event8.getShort(1), 253);
+        assertEquals(event8.getShort(2), 253);
+    }
+
+    @Test
     public void testSliceI8() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -354,6 +410,44 @@ public class TTreeDataSourceUnitTest {
         assertEquals(event8.numElements(), 2);
         assertEquals(event8.getByte(0), 125);
         assertEquals(event8.getByte(1), 125);
+    }
+
+    @Test
+    public void testSliceUI8() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceUI8").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new ShortType(), false), new SimpleType.ArrayType(SimpleType.fromString("uchar")), SimpleType.dtypeFromString("uchar"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getShort(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getShort(0), 2);
+        assertEquals(event2.getShort(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getShort(0), 1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getShort(0), 2);
+        assertEquals(event5.getShort(1), 2);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getShort(0), 254);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getShort(0), 253);
+        assertEquals(event8.getShort(1), 253);
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -699,6 +699,26 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testScalarUI32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarUI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new LongType(), SimpleType.fromString("uint"), SimpleType.dtypeFromString("uint"), cache, 0, 9, slim, null);
+        assertEquals(result.getLong(0), 0);
+        assertEquals(result.getLong(1), 1);
+        assertEquals(result.getLong(2), 2);
+        assertEquals(result.getLong(3), 0);
+        assertEquals(result.getLong(4), 1);
+        assertEquals(result.getLong(5), 2);
+        assertEquals(result.getLong(6), 4294967295L);
+        assertEquals(result.getLong(7), 4294967294L);
+        assertEquals(result.getLong(8), 4294967293L);
+    }
+
+    @Test
     public void testArrayI32() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -755,6 +775,62 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testArrayUI32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayUI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new LongType(), false), new SimpleType.ArrayType(SimpleType.fromString("uint")), SimpleType.dtypeFromString("uint"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getLong(0), 0);
+        assertEquals(event0.getLong(1), 0);
+        assertEquals(event0.getLong(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getLong(0), 1);
+        assertEquals(event1.getLong(1), 1);
+        assertEquals(event1.getLong(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getLong(0), 2);
+        assertEquals(event2.getLong(1), 2);
+        assertEquals(event2.getLong(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getLong(0), 0);
+        assertEquals(event3.getLong(1), 0);
+        assertEquals(event3.getLong(2), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getLong(0), 1);
+        assertEquals(event4.getLong(1), 1);
+        assertEquals(event4.getLong(2), 1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getLong(0), 2);
+        assertEquals(event5.getLong(1), 2);
+        assertEquals(event5.getLong(2), 2);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getLong(0), 4294967295L);
+        assertEquals(event6.getLong(1), 4294967295L);
+        assertEquals(event6.getLong(2), 4294967295L);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getLong(0), 4294967294L);
+        assertEquals(event7.getLong(1), 4294967294L);
+        assertEquals(event7.getLong(2), 4294967294L);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getLong(0), 4294967293L);
+        assertEquals(event8.getLong(1), 4294967293L);
+        assertEquals(event8.getLong(2), 4294967293L);
+    }
+
+    @Test
     public void testSliceI32() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -790,6 +866,44 @@ public class TTreeDataSourceUnitTest {
         assertEquals(event8.numElements(), 2);
         assertEquals(event8.getInt(0), 2147483645);
         assertEquals(event8.getInt(1), 2147483645);
+    }
+
+    @Test
+    public void testSliceUI32() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceUI32").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new LongType(), false), new SimpleType.ArrayType(SimpleType.fromString("uint")), SimpleType.dtypeFromString("uint"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getLong(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getLong(0), 2);
+        assertEquals(event2.getLong(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getLong(0), 1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getLong(0), 2);
+        assertEquals(event5.getLong(1), 2);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getLong(0), 4294967294L);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getLong(0), 4294967293L);
+        assertEquals(event8.getLong(1), 4294967293L);
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -927,6 +927,30 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testScalarUI64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarUI64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new DoubleType(), SimpleType.fromString("ulong"), SimpleType.dtypeFromString("ulong"), cache, 0, 9, slim, null);
+        assertEquals(result.getDouble(0), 0, 0.1);
+        assertEquals(result.getDouble(1), 1, 0.1);
+        assertEquals(result.getDouble(2), 2, 0.1);
+        assertEquals(result.getDouble(3), 0, 0.1);
+        assertEquals(result.getDouble(4), 1, 0.1);
+        assertEquals(result.getDouble(5), 2, 0.1);
+        /*
+         *  There's not enough bits in the mantissa to be able to tell the
+         *  difference between ULONG_MAX and (ULONG_MAX - 1). Oh well.
+         */
+        assertEquals(result.getDouble(6), 1.8446744073709552E19, 0.1);
+        assertEquals(result.getDouble(7), 1.8446744073709552E19, 0.1);
+        assertEquals(result.getDouble(8), 1.8446744073709552E19, 0.1);
+    }
+
+    @Test
     public void testArrayI64() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -983,6 +1007,62 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testArrayUI64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayUI64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new DoubleType(), false), new SimpleType.ArrayType(SimpleType.fromString("ulong")), SimpleType.dtypeFromString("ulong"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getDouble(0), 0, 0.1);
+        assertEquals(event0.getDouble(1), 0, 0.1);
+        assertEquals(event0.getDouble(2), 0, 0.1);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getDouble(0), 1, 0.1);
+        assertEquals(event1.getDouble(1), 1, 0.1);
+        assertEquals(event1.getDouble(2), 1, 0.1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getDouble(0), 2, 0.1);
+        assertEquals(event2.getDouble(1), 2, 0.1);
+        assertEquals(event2.getDouble(2), 2, 0.1);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getDouble(0), 0, 0.1);
+        assertEquals(event3.getDouble(1), 0, 0.1);
+        assertEquals(event3.getDouble(2), 0, 0.1);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getDouble(0), 1, 0.1);
+        assertEquals(event4.getDouble(1), 1, 0.1);
+        assertEquals(event4.getDouble(2), 1, 0.1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getDouble(0), 2, 0.1);
+        assertEquals(event5.getDouble(1), 2, 0.1);
+        assertEquals(event5.getDouble(2), 2, 0.1);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getDouble(0), 1.8446744073709552E19, 0.1);
+        assertEquals(event6.getDouble(1), 1.8446744073709552E19, 0.1);
+        assertEquals(event6.getDouble(2), 1.8446744073709552E19, 0.1);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getDouble(0), 1.8446744073709552E19, 0.1);
+        assertEquals(event7.getDouble(1), 1.8446744073709552E19, 0.1);
+        assertEquals(event7.getDouble(2), 1.8446744073709552E19, 0.1);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getDouble(0), 1.8446744073709552E19, 0.1);
+        assertEquals(event8.getDouble(1), 1.8446744073709552E19, 0.1);
+        assertEquals(event8.getDouble(2), 1.8446744073709552E19, 0.1);
+    }
+
+    @Test
     public void testSliceI64() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -1018,6 +1098,45 @@ public class TTreeDataSourceUnitTest {
         assertEquals(event8.numElements(), 2);
         assertEquals(event8.getLong(0), 9223372036854775805L);
         assertEquals(event8.getLong(1), 9223372036854775805L);
+    }
+
+    @Test
+    public void testSliceUI64() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceUI64").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new DoubleType(), false), new SimpleType.ArrayType(SimpleType.fromString("ulong")), SimpleType.dtypeFromString("ulong"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getDouble(0), 1, 0.1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getDouble(0), 2, 0.1);
+        assertEquals(event2.getDouble(1), 2, 0.1);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getDouble(0), 1, 0.1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getDouble(0), 2, 0.1);
+        assertEquals(event5.getDouble(1), 2, 0.1);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getDouble(0), 1.8446744073709552E19, 0.1);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getDouble(0), 1.8446744073709552E19, 0.1);
+        assertEquals(event8.getDouble(1), 1.8446744073709552E19, 0.1);
+        result.close();
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -16,6 +16,7 @@ import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.reader.InputPartition;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -220,6 +221,26 @@ public class TTreeDataSourceUnitTest {
         assertFloatArrayEquals(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, float32col.getArray(0).toFloatArray());
         assertFloatArrayEquals(new float[] { 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f}, float32col.getArray(10).toFloatArray());
         assertFloatArrayEquals(new float[] { 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f, 31.0f}, float32col.getArray(31).toFloatArray());
+    }
+
+    @Test
+    public void testScalarI1() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarI1").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new BooleanType(), SimpleType.fromString("bool"), SimpleType.dtypeFromString("bool"), cache, 0, 9, slim, null);
+        assertEquals(result.getBoolean(0), false);
+        assertEquals(result.getBoolean(1), true);
+        assertEquals(result.getBoolean(2), false);
+        assertEquals(result.getBoolean(3), true);
+        assertEquals(result.getBoolean(4), false);
+        assertEquals(result.getBoolean(5), true);
+        assertEquals(result.getBoolean(6), false);
+        assertEquals(result.getBoolean(7), true);
+        assertEquals(result.getBoolean(8), false);
     }
 
     @Test

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -471,6 +471,26 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testScalarUI16() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ScalarUI16").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new IntegerType(), SimpleType.fromString("ushort"), SimpleType.dtypeFromString("ushort"), cache, 0, 9, slim, null);
+        assertEquals(result.getInt(0), 0);
+        assertEquals(result.getInt(1), 1);
+        assertEquals(result.getInt(2), 2);
+        assertEquals(result.getInt(3), 0);
+        assertEquals(result.getInt(4), 1);
+        assertEquals(result.getInt(5), 2);
+        assertEquals(result.getInt(6), 65535);
+        assertEquals(result.getInt(7), 65534);
+        assertEquals(result.getInt(8), 65533);
+    }
+
+    @Test
     public void testArrayI16() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -527,6 +547,62 @@ public class TTreeDataSourceUnitTest {
     }
 
     @Test
+    public void testArrayUI16() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("ArrayUI16").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("ushort")), SimpleType.dtypeFromString("ushort"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 3);
+        assertEquals(event0.getInt(0), 0);
+        assertEquals(event0.getInt(1), 0);
+        assertEquals(event0.getInt(2), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 3);
+        assertEquals(event1.getInt(0), 1);
+        assertEquals(event1.getInt(1), 1);
+        assertEquals(event1.getInt(2), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 3);
+        assertEquals(event2.getInt(0), 2);
+        assertEquals(event2.getInt(1), 2);
+        assertEquals(event2.getInt(2), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 3);
+        assertEquals(event3.getInt(0), 0);
+        assertEquals(event3.getInt(1), 0);
+        assertEquals(event3.getInt(2), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 3);
+        assertEquals(event4.getInt(0), 1);
+        assertEquals(event4.getInt(1), 1);
+        assertEquals(event4.getInt(2), 1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 3);
+        assertEquals(event5.getInt(0), 2);
+        assertEquals(event5.getInt(1), 2);
+        assertEquals(event5.getInt(2), 2);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 3);
+        assertEquals(event6.getInt(0), 65535);
+        assertEquals(event6.getInt(1), 65535);
+        assertEquals(event6.getInt(2), 65535);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 3);
+        assertEquals(event7.getInt(0), 65534);
+        assertEquals(event7.getInt(1), 65534);
+        assertEquals(event7.getInt(2), 65534);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 3);
+        assertEquals(event8.getInt(0), 65533);
+        assertEquals(event8.getInt(1), 65533);
+        assertEquals(event8.getInt(2), 65533);
+    }
+
+    @Test
     public void testSliceI16() throws IOException {
         TFile file = TFile.getFromFile("testdata/all-types.root");
         TTree tree = new TTree(file.getProxy("Events"), file);
@@ -562,6 +638,44 @@ public class TTreeDataSourceUnitTest {
         assertEquals(event8.numElements(), 2);
         assertEquals(event8.getShort(0), 32765);
         assertEquals(event8.getShort(1), 32765);
+    }
+
+    @Test
+    public void testSliceUI16() throws IOException {
+        TFile file = TFile.getFromFile("testdata/all-types.root");
+        TTree tree = new TTree(file.getProxy("Events"), file);
+        TBranch branch = tree.getBranches("SliceUI16").get(0);
+        Cache cache = new Cache();
+        SlimTBranch slim = SlimTBranch.getFromTBranch(branch);
+
+        TTreeColumnVector result = new TTreeColumnVector(new ArrayType(new IntegerType(), false), new SimpleType.ArrayType(SimpleType.fromString("ushort")), SimpleType.dtypeFromString("ushort"), cache, 0, 9, slim, null);
+        ColumnarArray event0 = result.getArray(0);
+        assertEquals(event0.numElements(), 0);
+        ColumnarArray event1 = result.getArray(1);
+        assertEquals(event1.numElements(), 1);
+        assertEquals(event1.getInt(0), 1);
+        ColumnarArray event2 = result.getArray(2);
+        assertEquals(event2.numElements(), 2);
+        assertEquals(event2.getInt(0), 2);
+        assertEquals(event2.getInt(1), 2);
+        ColumnarArray event3 = result.getArray(3);
+        assertEquals(event3.numElements(), 0);
+        ColumnarArray event4 = result.getArray(4);
+        assertEquals(event4.numElements(), 1);
+        assertEquals(event4.getInt(0), 1);
+        ColumnarArray event5 = result.getArray(5);
+        assertEquals(event5.numElements(), 2);
+        assertEquals(event5.getInt(0), 2);
+        assertEquals(event5.getInt(1), 2);
+        ColumnarArray event6 = result.getArray(6);
+        assertEquals(event6.numElements(), 0);
+        ColumnarArray event7 = result.getArray(7);
+        assertEquals(event7.numElements(), 1);
+        assertEquals(event7.getInt(0), 65534);
+        ColumnarArray event8 = result.getArray(8);
+        assertEquals(event8.numElements(), 2);
+        assertEquals(event8.getInt(0), 65533);
+        assertEquals(event8.getInt(1), 65533);
     }
 
     @Test


### PR DESCRIPTION
This is prep work to try and correctly parse unsigned integers. This
brings up an interesting problem because the on-disk and in-memory sizes
of the types are different (so it's not just the matter of simply
casting the values). The general idea is to completely implement the
disk and memory buffers separately while I sort out exactly the
different interactions I need to handle, then once things are
functional, I can pare away the extra buffer.